### PR TITLE
Fix the dealer's bust logic

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -77,12 +77,10 @@ class BlackjackGUI:
         self.hit_button.config(state=tk.DISABLED)
         self.stand_button.config(state=tk.DISABLED)
 
-        d_status = self.blackjack_game.dealer.deal()
         self.update_ui()
 
-        if d_status == 1:
-            messagebox.showinfo("Blackjack", "Dealer got Blackjack!")
-            self.end_game()
+        if self.blackjack_game.dealer.check_score() == 21:
+            self.determine_winner()
             return
 
         while self.blackjack_game.dealer.check_score() < 17:


### PR DESCRIPTION
This commit fixes an issue where the dealer would still win even after busting. The `stand` method in `gui.py` has been updated to correctly handle the case where the dealer's score exceeds 21. The incorrect call to `deal` has been removed and a check for blackjack has been added after the dealer's first turn.